### PR TITLE
Add ability to export SceneGraph file in batch mode

### DIFF
--- a/app/Batch.cpp
+++ b/app/Batch.cpp
@@ -200,6 +200,11 @@ void BatchContext::addToCommandLine(std::shared_ptr<CLI::App> app) {
     },
     "Set the renderer background color"
     )->expected(4);
+  app->add_flag(
+    "--saveScene",
+    saveScene,
+    "Saves the SceneGraph representing the frame"
+  );
 }
 
 bool BatchContext::parseCommandLine()
@@ -424,6 +429,16 @@ void BatchContext::renderFrame()
     frame->saveFrame(filename, screenshotFlags);
 
     this->outputFilename = filename;
+
+    if (saveScene)
+    {
+      std::ofstream dump("studio_scene.sg");
+      JSON j = {{"world", frame->child("world")},
+          {"camera", arcballCamera->getState()},
+          {"lightsManager", *lightsManager},
+          {"materialRegistry", *baseMaterialRegistry}};
+      dump << j.dump();
+    }
   }
   
   pluginManager->main(shared_from_this());

--- a/app/Batch.h
+++ b/app/Batch.h
@@ -69,6 +69,9 @@ class BatchContext : public StudioContext
   float lockAspectRatio = 0.0;
   bool useArcball{false};
 
+  // SceneGraph
+  bool saveScene{false};
+
   // CLI
   std::string optImageName = "ospBatch";
 };


### PR DESCRIPTION
I'm experimenting with an OSPRay Studio usage where the end user can directly edit the SceneGraph through a web interface. This relies upon batch mode to do the renderings, and adding this flag to batch mode makes it possible to get the initial SceneGraph to provide to the end user once the first rendering is complete.